### PR TITLE
Pull request from alanhortz/node-metawear

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "node-metawear",
   "version": "0.2.2",
   "description": "API for metawear",
+  "main" : "device.js",
   "dependencies": {
     "debug": "~2.2",
     "eventemitter2": "~0.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "debug": "~2.2",
     "eventemitter2": "~0.4",
-    "noble-device": "~1.1"
+    "noble-device": "~1.2"
   },
   "devDependencies": {
     "buffer-equal": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "noble-device": "~1.1"
   },
   "devDependencies": {
+    "buffer-equal": "^1.0.0",
     "jasmine": "^2.4.1",
     "jasmine-spec-reporter": "^2.4.0",
     "mocha": "~2.4"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "noble-device": "~1.1"
   },
   "devDependencies": {
+    "jasmine": "^2.4.1",
+    "jasmine-spec-reporter": "^2.4.0",
     "mocha": "~2.4"
   },
   "keywords": [
@@ -23,7 +25,7 @@
   },
   "repository": "git@github.com:brainexe/node-metawear.git",
   "scripts": {
-    "test": "cd tests && mocha spec/**"
+    "test": "cd tests && node jasmine-runner.js"
   },
   "author": "Matthias Dötsch <matze@mdoetsch.de>",
   "license": "MIT"

--- a/src/registers/accelerometer.js
+++ b/src/registers/accelerometer.js
@@ -133,8 +133,8 @@ Accelerometer.prototype.setConfig = function() {
     var buffer = new Buffer(4);
     buffer[0] = MODULE_OPCODE;
     buffer[1] = DATA_CONFIG;
-    buffer[2] = 0x05; // TODO set correct value
-    buffer[3] = 0x06;
+    buffer[2] = 0x20 | this.dataRate;
+    buffer[3] = this.accRange[0];
     this.device.send(buffer);
 };
 

--- a/src/registers/accelerometer.js
+++ b/src/registers/accelerometer.js
@@ -71,8 +71,8 @@ const ACC_RANGE = {
 
 var Accelerometer = function(device) {
     this.device   = device;
-    this.dataRate = this.setOutputDataRate(50);
-    this.accRange = this.setAxisSamplingRange(2);
+    this.setOutputDataRate(50);
+    this.setAxisSamplingRange(2);
 };
 
 Accelerometer.prototype.start = function() {

--- a/tests/jasmine-runner.js
+++ b/tests/jasmine-runner.js
@@ -1,0 +1,9 @@
+var Jasmine = require('jasmine');
+var SpecReporter = require('jasmine-spec-reporter');
+var noop = function() {};
+
+var jrunner = new Jasmine();
+jrunner.configureDefaultReporter({print: noop});    // remove default reporter logs
+jasmine.getEnv().addReporter(new SpecReporter());   // add jasmine-spec-reporter
+jrunner.loadConfigFile();                           // load jasmine.json configuration
+jrunner.execute();

--- a/tests/spec/registers/accelerometerSpec.js
+++ b/tests/spec/registers/accelerometerSpec.js
@@ -12,6 +12,23 @@ describe("Accelerometer", function() {
 		it("should have +-2g as default axis sampling range", function() {
 			expect(accelerometer.accRange).toEqual([0x3,    16384]);
 		});
+
+		describe("setConfig()", function() {
+			
+			beforeEach(function() {
+				//device = new Device();
+				spyOn(device, 'send').and.callThrough();
+			});
+
+			it("should send the configured output data rate and axis sampling range to the MetaWear device", function() {
+				accelerometer.setConfig();
+				expect(device.send).toHaveBeenCalled();
+				expect(Buffer.compare(
+						device.buffers.pop(),
+						new Buffer([0x3,0x3,0x27,0x3]))
+				).toEqual(0); // Buffer.compare returns 0 when the two buffers are equal !
+			});
+		});
 				
 });
 

--- a/tests/spec/registers/accelerometerSpec.js
+++ b/tests/spec/registers/accelerometerSpec.js
@@ -2,15 +2,9 @@ var Accelerometer = require('../../../src/registers/accelerometer'),
     Device   = require('../helpers/device'),
     bufferEqual = require('buffer-equal');
 
-
-
-
-
 describe("Accelerometer", function() {
 		var device = new Device(),
 				accelerometer = new Accelerometer(device);
-
-
 
 		it("should have 50hz as default value for output data rate", function() {
 			expect(accelerometer.dataRate).toEqual(0x7);

--- a/tests/spec/registers/accelerometerSpec.js
+++ b/tests/spec/registers/accelerometerSpec.js
@@ -17,7 +17,6 @@ describe("Accelerometer", function() {
 		describe("setConfig()", function() {
 			
 			beforeEach(function() {
-				//device = new Device();
 				spyOn(device, 'send').and.callThrough();
 				jasmine.addCustomEqualityTester(bufferEqual);
 			});

--- a/tests/spec/registers/accelerometerSpec.js
+++ b/tests/spec/registers/accelerometerSpec.js
@@ -1,9 +1,16 @@
 var Accelerometer = require('../../../src/registers/accelerometer'),
-    Device   = require('../helpers/device');
+    Device   = require('../helpers/device'),
+    bufferEqual = require('buffer-equal');
+
+
+
+
 
 describe("Accelerometer", function() {
 		var device = new Device(),
 				accelerometer = new Accelerometer(device);
+
+
 
 		it("should have 50hz as default value for output data rate", function() {
 			expect(accelerometer.dataRate).toEqual(0x7);
@@ -18,15 +25,14 @@ describe("Accelerometer", function() {
 			beforeEach(function() {
 				//device = new Device();
 				spyOn(device, 'send').and.callThrough();
+				jasmine.addCustomEqualityTester(bufferEqual);
 			});
 
 			it("should send the configured output data rate and axis sampling range to the MetaWear device", function() {
 				accelerometer.setConfig();
 				expect(device.send).toHaveBeenCalled();
-				expect(Buffer.compare(
-						device.buffers.pop(),
-						new Buffer([0x3,0x3,0x27,0x3]))
-				).toEqual(0); // Buffer.compare returns 0 when the two buffers are equal !
+
+				expect(device.buffers.pop()).toEqual(new Buffer([0x3,0x3,0x27,0x3]));
 			});
 		});
 				

--- a/tests/spec/registers/accelerometerSpec.js
+++ b/tests/spec/registers/accelerometerSpec.js
@@ -1,0 +1,17 @@
+var Accelerometer = require('../../../src/registers/accelerometer'),
+    Device   = require('../helpers/device');
+
+describe("Accelerometer", function() {
+		var device = new Device(),
+				accelerometer = new Accelerometer(device);
+
+		it("should have 50hz as default value for output data rate", function() {
+			expect(accelerometer.dataRate).toEqual(0x7);
+		});
+
+		it("should have +-2g as default axis sampling range", function() {
+			expect(accelerometer.accRange).toEqual([0x3,    16384]);
+		});
+				
+});
+

--- a/tests/spec/registers/switchSpec.js
+++ b/tests/spec/registers/switchSpec.js
@@ -1,7 +1,6 @@
 
 var
     Register = require('../../../src/registers/switch'),
-    assert   = require("assert"),
     device   = new (require('../helpers/device'));
 
 describe("Test switch register", function() {
@@ -9,8 +8,7 @@ describe("Test switch register", function() {
 
     it("enable listener", function() {
         subject.register();
-
-        //assert.equal([new Buffer('010101', 'hex')], device.buffers);
-        assert.equal(device.buffers.pop().toString(), new Buffer('010101', 'hex').toString());
+        expect(device.buffers.pop().toString()).toEqual(new Buffer('010101', 'hex').toString());
+        
     });
 });

--- a/tests/spec/support/jasmine.json
+++ b/tests/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
PR from @alanhortz 
- fixed Accellerometer.setConfig() which is not setting the correct values instead of dummy config
- improved test cases
- require at least noble-device version 1.2
